### PR TITLE
Heading/Footer Better Mobile UI

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -36,7 +36,7 @@ const currentDate = new Date().getTime();
         <Img src="/logo.png" class="nav-icon" alt="Website Logo" />
       </a>
       <hr class="nav-slash" />
-      <a target="_blank" href="https://titaniumnetwork.org">
+      <a target="_blank" href="https://titaniumnetwork.org" class="tn-container">
         <Img src="/tn.png" class="tn-icon" alt="TN Icon" />
       </a>
 

--- a/src/sections/footer.css
+++ b/src/sections/footer.css
@@ -10,12 +10,14 @@
 
 .footer-container {
     display: flex;
+    flex-wrap: wrap;
     height: 100%;
     width: 100%;
     position: relative;
     justify-content: space-evenly;
     align-items: center;
-    gap: 2px;
+    gap: 14px;
+    margin-top: 16px;
 }
 
 .site-footer .top-banner {
@@ -23,11 +25,11 @@
     width: 100%;
     font-size: 20px;
     color: var(--font-color);
-    top: -16px;
+    top: -1px;
     position: relative;
     text-align: center;
     z-index: 2;
-    padding: 1px 0 0 0;
+    padding: 2px 0 0 0;
 }
 
 .top-banner::before {
@@ -117,10 +119,12 @@
 }
 
 .flex-footer-container {
+    flex: 1;
     display: flex;
     flex-direction: row;
-    justify-content: center;
+    justify-content: space-evenly;
     align-items: center;
+    width: 100%;
     gap: 20px;
 }
 

--- a/src/sections/header.css
+++ b/src/sections/header.css
@@ -30,7 +30,18 @@
 .nav-btns {
     display: flex;
     justify-content: flex-start;
+    padding-left: 10px;
+    padding-right: 10px;
     width: 500px;
+    @media screen and (max-width: 760px) {
+        width: 100%;
+        float: none;
+        gap: 10px;
+
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+    }
     float: left;
     position: relative;
     transition: all 0.1s ease, margin-left 0.3s ease;
@@ -74,11 +85,13 @@
 .top-left {
     text-align: left;
     display: inline-block;
-    
+
+    @media screen and (max-width: 760px) {
+        text-align: center;
+    }
+
     flex: 1;
     transition: padding-left 0.3s ease;
-    
-    
 }
 
 .nav-icon {
@@ -90,6 +103,13 @@
     /*animation: breathe 4s ease;*/
 }
 
+.tn-container {
+    @media screen and (max-width: 760px) {
+        display: none;
+    }
+}
+
+/* Hide if the screen is less than 760px */
 .tn-icon {
     width: 40px;
     height: 40px;
@@ -116,6 +136,9 @@
 .nav-slash {
     border-top: var(--borders-1);
     width: 24px;
+    @media screen and (max-width: 760px) {
+        display: none;
+    }
     display: inline-block;
     transform: rotate(120deg);
     position: relative;
@@ -136,11 +159,15 @@
 .top-right {
     text-align: right;
     display: inline-block;
+    @media screen and (max-width: 760px) {
+        display: none;
+    }
     flex: 1;
     /*width: 50%;*/
 }
 
-.header .top-right, .header .switch-btn-container {
+.header .top-right,
+.header .switch-btn-container {
     transition: 0.1s ease;
 }
 
@@ -155,8 +182,6 @@
     position: relative;
     transition: 0.1s ease;
 }
-
-
 
 .extra-btn {
     margin-left: 15px;
@@ -173,6 +198,10 @@
 }
 
 .nav-time {
+    @media screen and (max-width: 760px) {
+        display: none;
+    }
+
     margin: 0;
     padding: 6px 0 6px 0;
     flex: auto;
@@ -181,6 +210,7 @@
     position: relative;
     transition: 0.1s ease;
     z-index: -1;
+    pointer-events: none;
     text-align: right;
 }
 
@@ -201,5 +231,5 @@
     display: inline-block;
     position: relative;
     top: 6px;
-    cursor: pointer
+    cursor: pointer;
 }

--- a/src/sections/switch.css
+++ b/src/sections/switch.css
@@ -1,8 +1,8 @@
 .switch-btn-container {
     position: relative;
     display: inline-block;
-    margin-left: 25px;
-    margin-right: 20px;
+    margin-left: 15px;
+    margin-right: 15px;
     cursor: pointer;
     vertical-align: middle;
 }


### PR DESCRIPTION
Removes the TN logo and time when smaller than 760px, adjusted some of the spacing between elements, fixed wrapping on the footer, and overall made the UI much easier for mobile users to use.

See video for changes:
before: https://github.com/NocturaProxy/Frontend/assets/72959444/90e65ca8-dc84-4be2-8927-621010c0d6a2
after: https://github.com/NocturaProxy/Frontend/assets/72959444/f2838796-b580-4586-9260-e005e3712e55

